### PR TITLE
Change .schema-file structure

### DIFF
--- a/.cards/local/.schema
+++ b/.cards/local/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardsConfigSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardsConfigSchema",
+        "version": 1
+    }
+]

--- a/.cards/local/cardTypes/.schema
+++ b/.cards/local/cardTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/local/fieldTypes/.schema
+++ b/.cards/local/fieldTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "fieldTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "fieldTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/local/linkTypes/.schema
+++ b/.cards/local/linkTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "linkTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "linkTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/local/workflows/.schema
+++ b/.cards/local/workflows/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "workflowSchema",
-    "version": 1
-}
+[
+    {
+        "id": "workflowSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/.schema
+++ b/.cards/modules/base/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardsConfigSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardsConfigSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/cardTypes/.schema
+++ b/.cards/modules/base/cardTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/fieldTypes/.schema
+++ b/.cards/modules/base/fieldTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "fieldTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "fieldTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/linkTypes/.schema
+++ b/.cards/modules/base/linkTypes/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "linkTypeSchema",
-    "version": 1
-}
+[
+    {
+        "id": "linkTypeSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/annualTask/.schema
+++ b/.cards/modules/base/templates/annualTask/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/annualTask/c/.schema
+++ b/.cards/modules/base/templates/annualTask/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/controlledDocument/.schema
+++ b/.cards/modules/base/templates/controlledDocument/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/controlledDocument/c/.schema
+++ b/.cards/modules/base/templates/controlledDocument/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/decision/.schema
+++ b/.cards/modules/base/templates/decision/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/decision/c/.schema
+++ b/.cards/modules/base/templates/decision/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/meetingMemo/.schema
+++ b/.cards/modules/base/templates/meetingMemo/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/meetingMemo/c/.schema
+++ b/.cards/modules/base/templates/meetingMemo/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/monthlyTask/.schema
+++ b/.cards/modules/base/templates/monthlyTask/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/monthlyTask/c/.schema
+++ b/.cards/modules/base/templates/monthlyTask/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/oneTimeTask/.schema
+++ b/.cards/modules/base/templates/oneTimeTask/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/oneTimeTask/c/.schema
+++ b/.cards/modules/base/templates/oneTimeTask/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/page/.schema
+++ b/.cards/modules/base/templates/page/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/page/c/.schema
+++ b/.cards/modules/base/templates/page/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/quarterlyTask/.schema
+++ b/.cards/modules/base/templates/quarterlyTask/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "templateSchema",
-    "version": 1
-}
+[
+    {
+        "id": "templateSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/templates/quarterlyTask/c/.schema
+++ b/.cards/modules/base/templates/quarterlyTask/c/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/.cards/modules/base/workflows/.schema
+++ b/.cards/modules/base/workflows/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "workflowSchema",
-    "version": 1
-}
+[
+    {
+        "id": "workflowSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/.schema
+++ b/cardRoot/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/docs_13/.schema
+++ b/cardRoot/docs_13/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/docs_14/.schema
+++ b/cardRoot/docs_14/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/docs_2/.schema
+++ b/cardRoot/docs_2/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/docs_6/c/docs_12/.schema
+++ b/cardRoot/docs_6/c/docs_12/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]

--- a/cardRoot/docs_6/c/docs_9/.schema
+++ b/cardRoot/docs_6/c/docs_9/.schema
@@ -1,4 +1,6 @@
-{
-    "id": "cardBaseSchema",
-    "version": 1
-}
+[
+    {
+        "id": "cardBaseSchema",
+        "version": 1
+    }
+]


### PR DESCRIPTION
Content schema files (.schema) have now new structure; they are arrays of objects instead of just objects. This allows to use different content schema for certain files. 

Additionally, add ´reports´ sub-folder to `.cards/local`