### PR TITLE
INTDEV-565 Install pnpm in pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install the Cyberismo application
         run: |
           cd cyberismo


### PR DESCRIPTION
The previous build failed, because pipeline commands were updated to use pnpm, but pnpm was not installed