### PR TITLE
Remove unnecessary .schema files

### DIFF
--- a/cardRoot/docs_13/.schema
+++ b/cardRoot/docs_13/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_14/.schema
+++ b/cardRoot/docs_14/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_2/.schema
+++ b/cardRoot/docs_2/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_4/.schema
+++ b/cardRoot/docs_4/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_4/c/docs_i5v1ydlh/.schema
+++ b/cardRoot/docs_4/c/docs_i5v1ydlh/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_6/.schema
+++ b/cardRoot/docs_6/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]

--- a/cardRoot/docs_6/c/docs_9/.schema
+++ b/cardRoot/docs_6/c/docs_9/.schema
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "cardBaseSchema",
-        "version": 1
-    }
-]


### PR DESCRIPTION
There was a bug in cyberismo application where it created an unnecessary `.schema` file each time cards were added from template. 
Bug is reported here: https://cyberismo.atlassian.net/browse/INTDEV-589
And PR is here: https://github.com/CyberismoCom/cyberismo/pull/314 - it has been merged to 'main'

As a fix, remove unnecessary `.schema` files from this content repository.