### PR TITLE
INTDEV-785 Update to NodeJS v.22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     environment:
       name: github-pages

--- a/cardRoot/docs_13/c/docs_17/c/docs_9d8e92fm/index.adoc
+++ b/cardRoot/docs_13/c/docs_17/c/docs_9d8e92fm/index.adoc
@@ -1,14 +1,14 @@
 == Recommended method for Linux
 
 On Linux, the easiest way to try Cyberismo is likely by using a container platform such as xref:docs_w0puey08.adoc[Docker] or xref:docs_il74geqj.adoc[Podman].
- 
+
 == Building and running Cyberismo locally from source
 
 === Prerequisites
 
 Install Git. While Cyberismo does not directly depend on Git, you will need it to manage Cyberismo content, such as when installing Cyberismo modules. Git installation guide: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 
-Install Node.js. The currently supported Node.js version is the latest LTS, v20.10.0. Node.js is downloadable from https://nodejs.org/.
+Install Node.js. The currently supported Node.js version is the latest LTS, v22.14.0. Node.js is downloadable from https://nodejs.org/.
 
 *Ubuntu 20.04* and newer support automatic dependency installation via a post-install script. The post-install script will download a working clingo binary into the project directory and verify the presence of graphviz, which must be installed manually if it is not already present. Graphviz can be installed with the following command:
 
@@ -27,7 +27,7 @@ Take the following steps:
 . Clone the source repository:
 
   $ git clone https://github.com/CyberismoCom/cyberismo.git
-  
+
 . Change to the source directory. If you have already cloned the repository earlier, remember to pull the latest changes:
 
   $ cd cyberismo
@@ -36,7 +36,7 @@ Take the following steps:
 . Install pnpm with npm command:
 
   $ npm install -g pnpm
-  
+
 . Execute the following commands:
 
   $ pnpm setup

--- a/cardRoot/docs_13/c/docs_17/c/docs_f90j31tm/index.adoc
+++ b/cardRoot/docs_13/c/docs_17/c/docs_f90j31tm/index.adoc
@@ -8,7 +8,7 @@ On macOS, the easiest way to try Cyberismo is likely by using a container platfo
 
 Install Git. While Cyberismo does not directly depend on Git, you will need it to manage Cyberismo content, such as when installing Cyberismo modules. Git installation guide: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 
-Install Node.js. The currently supported Node.js version is the latest LTS, v20.10.0. Node.js is downloadable from https://nodejs.org/.
+Install Node.js. The currently supported Node.js version is the latest LTS, v22.14.0. Node.js is downloadable from https://nodejs.org/.
 
 When building Cyberismo on macOS, there is a utility script which you can use to install a minimal Python distribution Miniconda and the required dependencies under the `vendor` directory in the Cyberismo main directory. Instructions are provided below.
 
@@ -19,7 +19,7 @@ Take the following steps:
 . Clone the source repository:
 
   $ git clone https://github.com/CyberismoCom/cyberismo.git
-  
+
 . Change to the source directory. If you have already cloned the repository earlier, remember to pull the latest changes:
 
   $ cd cyberismo
@@ -28,7 +28,7 @@ Take the following steps:
 . Install pnpm with npm command:
 
   $ npm install -g pnpm
-  
+
 . Execute the following commands:
 
   $ pnpm setup
@@ -38,7 +38,7 @@ Take the following steps:
 
 . On macOS, you can install the dependencies with
 
-  $ pnpm install-dev-packages  
+  $ pnpm install-dev-packages
 
 === Running
 

--- a/cardRoot/docs_13/c/docs_17/c/docs_pw3rj3a9/index.adoc
+++ b/cardRoot/docs_13/c/docs_17/c/docs_pw3rj3a9/index.adoc
@@ -4,7 +4,7 @@
 
 Install Git. While Cyberismo does not directly depend on Git, you will need it to manage Cyberismo content, such as when installing Cyberismo modules. Git can be downloaded from https://git-scm.com/downloads/win
 
-Install Node.js. The currently supported Node.js version is the latest LTS, v20.10.0. Node.js is downloadable from https://nodejs.org/.
+Install Node.js. The currently supported Node.js version is the latest LTS, v22.14.0. Node.js is downloadable from https://nodejs.org/.
 
 When building Cyberismo on Windows, the system automatically installs the required dependencies (Clingo and libraries) using a prebuilt package by Cyberismo.
 
@@ -15,12 +15,12 @@ Take the following steps:
 . Clone the source repository:
 
   $ git clone https://github.com/CyberismoCom/cyberismo.git
-  
+
 . Change to the source directory. If you have already cloned the repository earlier, remember to pull the latest changes:
 
   $ cd cyberismo
   $ git pull origin main # Optional
-  
+
 . Install pnpm with npm command:
 
   $ npm install -g pnpm


### PR DESCRIPTION
Update the required nodeJS to be v.22.

Docs claimed that the latest LTS for v.20 was 20.10.0, when nodeJS had already moved to 20.19.0 (few weeks ago).
Not sure if it makes sense to have minor/major version here in the docs. Maybe just the "v.22" would be enough. That way we don't have to update docs whenever nodeJS version moves forward.
  

