### PR TITLE
Use 'import from git'-functionality

### DIFF
--- a/cardRoot/docs_2/c/docs_7/index.adoc
+++ b/cardRoot/docs_2/c/docs_7/index.adoc
@@ -3,15 +3,6 @@ This tutorial shows how to create a new Cyberismo project with the base module.
 
 Prerequisites: xref:docs_13.adoc[Install Cyberismo].
 
-== Clone the base module
-
-Execute the following command to clone the base module:
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-base.git
-----
-
 == Create a project
 
 First, let's check the command line help for creating a project by executing the following command:
@@ -47,7 +38,7 @@ Import the base module to your new project with the following command:
 
 [source,console]
 ----
-$ cyberismo import module module-base -p cyberismo-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-base.git -p cyberismo-tutorial
 ----
 
 == Create a page

--- a/cardRoot/docs_2/c/docs_krxdf4ke/index.adoc
+++ b/cardRoot/docs_2/c/docs_krxdf4ke/index.adoc
@@ -11,28 +11,6 @@ This module includes a powerful threat modeling tool that enables the modeling o
 
 xref:docs_13.adoc[Install Cyberismo].
 
-== Clone the required Cyberismo modules
-
-The Cyberismo secure development essentials module builds on the base module and the ISMS essentials module as its prerequisites.
-
-Execute the following command to clone the required modules:
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-base.git
-----
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-isms-essentials.git
-----
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-secure-development-essentials.git
-----
-
-
 == Create a project
 
 Create a new project called, for example, "Secure development tutorial" that has the card key prefix `mysecdev` in the directory `secdev-tutorial` with the following command:
@@ -44,21 +22,23 @@ $ cyberismo create project "Secure development tutorial" mysecdev secdev-tutoria
 
 == Import the modules to your new project
 
+The Cyberismo secure development essentials module builds on the base module and the ISMS essentials module as its prerequisites.
+
 Import the required modules to your new project with the following commands:
 
 [source,console]
 ----
-$ cyberismo import module module-base -p secdev-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-base.git -p secdev-tutorial
 ----
 
 [source,console]
 ----
-$ cyberismo import module module-isms-essentials -p secdev-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-isms-essentials.git -p secdev-tutorial
 ----
 
 [source,console]
 ----
-$ cyberismo import module module-secure-development-essentials -p secdev-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-secure-development-essentials.git -p secdev-tutorial
 ----
 
 == Start the Cyberismo app

--- a/cardRoot/docs_2/c/docs_y9v6f19e/index.adoc
+++ b/cardRoot/docs_2/c/docs_y9v6f19e/index.adoc
@@ -14,20 +14,6 @@ along with the needed field types, link types, templates, workflows, registers, 
 
 xref:docs_13.adoc[Install Cyberismo].
 
-== Clone the required Cyberismo modules
-
-Execute the following command to clone the Cyberismo base module and the Cyberismo ISMS essentials module:
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-base.git
-----
-
-[source,console]
-----
-$ git clone https://github.com/CyberismoCom/module-isms-essentials.git
-----
-
 == Create a project
 
 Create a new project called, for example, "ISMS tutorial" that has the card key prefix `myisms` in the directory `isms-tutorial` with the following command:
@@ -43,12 +29,12 @@ Import the Cyberismo base module and the Cyberismo ISMS essentials module to you
 
 [source,console]
 ----
-$ cyberismo import module module-base -p isms-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-base.git -p isms-tutorial
 ----
 
 [source,console]
 ----
-$ cyberismo import module module-isms-essentials -p isms-tutorial
+$ cyberismo import module https://github.com/CyberismoCom/module-isms-essentials.git -p isms-tutorial
 ----
 
 == Create a home page for your project
@@ -80,7 +66,7 @@ Then open a browser and navigate to http://localhost:3000/.
 
 == Explore your new ISMS workspace
 
-Now you are ready to explore your new ISMS workspace. 
+Now you are ready to explore your new ISMS workspace.
 
 * Expand the navigation tree on the left to see the structure of the documentation
 * See progress key performance indicators both in the navigation tree and on the home page


### PR DESCRIPTION
There is a new functionality available in 'cyberismo'. You can import modules directly from git instead of first cloning the repositories and then importing from filesystem. As this removes one whole step in tutorial use it in the docs example.