### PR TITLE
Add documentation about dataType predicate

### DIFF
--- a/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_8mg8p068/index.adoc
+++ b/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_8mg8p068/index.adoc
@@ -9,3 +9,5 @@
 The `field` predicate declares that a field of an object has a specific value.
 
 Cyberismo generates `field` facts for the properties of cards and other resources. Logic programs can use `field` in the heads of rules to define calculated fields.
+
+When you define values of fields with facts or rules, the logic program also needs to include information about the data type of the field. If the field is based on a field type configuration, then the data type is available automatically from the field type, but in other cases, you should also define a data type for the field using `{{#xref}}"cardKey":"docs_aozy8cfm"{{/xref}}`.

--- a/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_8mg8p068/index.json
+++ b/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_8mg8p068/index.json
@@ -3,10 +3,15 @@
     "cardType": "base/cardTypes/predicate",
     "workflowState": "Ready",
     "rank": "0|c",
-    "lastUpdated": "2025-07-01T08:53:33.609Z",
+    "lastUpdated": "2025-11-10T18:57:38.036Z",
     "base/fieldTypes/briefDescription": "A field of an object has a specific value",
     "base/fieldTypes/category": "Cards",
-    "links": [],
+    "links": [
+        {
+            "linkType": "base/linkTypes/relatesTo",
+            "cardKey": "docs_aozy8cfm"
+        }
+    ],
     "templateCardKey": "base_weu9g7lz",
     "lastTransitioned": "2025-07-01T06:46:33.778Z"
 }

--- a/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_aozy8cfm/index.adoc
+++ b/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_aozy8cfm/index.adoc
@@ -1,0 +1,17 @@
+== Parameters
+
+* `Key`: an object, such as a card
+* `Field`: a fiel of the object `Key`
+* `DataType`: the data type of the field `Field` of `Key`
+
+== Description
+
+The `dataType` predicate declares that a field of an object has a specific data type. For a list of available data types, see {{#xref}}"cardKey":"docs_25"{{/xref}}.
+
+When you define values of fields with facts or rules using {{#xref}}"cardKey":"docs_8mg8p068"{{/xref}}, the logic program also needs to include information about the data type of the field. If the field is a calculated field of a card, where the field is defined with a field type configuration and included in the card type, then the data type is available automatically from the field type.
+
+However, if the field is not associated with a field type configuration, for example because it is a temporary calculated field of a query result, then you need to define a data type for the field using the `dataType` predicate. In queries, you can alternatively use the {{#xref}}"cardKey":"docs_bnakwi6w"{{/xref}} predicate.
+
+
+
+

--- a/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_aozy8cfm/index.json
+++ b/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_aozy8cfm/index.json
@@ -1,0 +1,11 @@
+{
+    "title": "dataType(Key, Field, DataType)",
+    "cardType": "base/cardTypes/predicate",
+    "workflowState": "Draft",
+    "rank": "0|j",
+    "lastUpdated": "2025-11-10T18:52:10.250Z",
+    "base/fieldTypes/briefDescription": "A field of an object has a specific data type",
+    "base/fieldTypes/category": "Cards",
+    "links": [],
+    "templateCardKey": "base_weu9g7lz"
+}

--- a/cardRoot/docs_6/c/docs_9/c/docs_33/c/docs_bnakwi6w/index.adoc
+++ b/cardRoot/docs_6/c/docs_9/c/docs_33/c/docs_bnakwi6w/index.adoc
@@ -7,7 +7,7 @@
 
 == Description
 
-The `field` predicate with 4 parameters is a helper that enables a single rule in a query to define a field and its data type.
+The `field` predicate with 4 parameters is a helper that enables a single rule in a query to define a field and its data type. This is useful, for example, in queries that define new fields of query results, for which there is no field type configuration.
 
 This predicate has been implemented with the following rules.
 

--- a/cardRoot/docs_6/c/docs_9/c/docs_33/c/docs_bnakwi6w/index.json
+++ b/cardRoot/docs_6/c/docs_9/c/docs_33/c/docs_bnakwi6w/index.json
@@ -3,10 +3,19 @@
     "cardType": "base/cardTypes/predicate",
     "workflowState": "Ready",
     "rank": "0|ap",
-    "lastUpdated": "2025-07-01T09:34:20.729Z",
+    "lastUpdated": "2025-11-10T18:58:09.304Z",
     "base/fieldTypes/briefDescription": "A field of an object has a specific value and data type",
     "base/fieldTypes/category": "Query language",
-    "links": [],
+    "links": [
+        {
+            "linkType": "base/linkTypes/relatesTo",
+            "cardKey": "docs_aozy8cfm"
+        },
+        {
+            "linkType": "base/linkTypes/relatesTo",
+            "cardKey": "docs_8mg8p068"
+        }
+    ],
     "templateCardKey": "base_weu9g7lz",
     "lastTransitioned": "2025-07-01T09:34:20.729Z"
 }


### PR DESCRIPTION
Documentation for dataType was missing. I also improved the documentation for field predicate.

Maybe we should move the definition of the 4 parameter field(Key, Field, Value, DataType) from the query language to base.lp?